### PR TITLE
Fix IE Metal Press recipes having the wrong process energy

### DIFF
--- a/src/main/java/wanion/unidict/integration/IEIntegration.java
+++ b/src/main/java/wanion/unidict/integration/IEIntegration.java
@@ -120,7 +120,7 @@ final class IEIntegration extends AbstractIntegrationThread
 				continue;
 			final int id = MetaItem.getCumulative(output, metalPressRecipe.mold.stack);
 			if (!uniques.contains(id)) {
-				correctRecipes.put(metalPressRecipe.mold, new MetalPressRecipe(output, metalPressRecipe.input, metalPressRecipe.mold, (int) Math.floor((double) ((float) metalPressRecipe.getTotalProcessEnergy() / MetalPressRecipe.timeModifier))).setInputSize(metalPressRecipe.input.inputSize));
+				correctRecipes.put(metalPressRecipe.mold, new MetalPressRecipe(output, metalPressRecipe.input, metalPressRecipe.mold, (int) Math.floor((double) ((float) metalPressRecipe.getTotalProcessEnergy() / MetalPressRecipe.energyModifier))).setInputSize(metalPressRecipe.input.inputSize));
 				uniques.add(id);
 			}
 			metalPressRecipesIterator.remove();


### PR DESCRIPTION
Noticed metal press recipes used way too much energy, found this little typo.